### PR TITLE
Kill threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.so
 *.class
 *.hprof
+hs_err_*.log
+tests

--- a/JvmKillTest2.java
+++ b/JvmKillTest2.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.ArrayList;
+import java.util.List;
+
+public final class JvmKillTest2
+{
+    private static final int MAXNUM = 2048;
+
+    @SuppressWarnings("InfiniteLoopStatement")
+    public static void main(String[] args)
+            throws Exception
+    {
+        System.out.println("triggering OutOfMemmoryError due to thread exhaustion...");
+        List<Thread> list = new ArrayList<>();
+        try {
+            for (int n = 0; n < MAXNUM; ++n) {
+                final int num = n;
+                Thread t = new Thread(){
+                    private final String name = "Thread number " + num;
+                    @Override
+                    public void run() {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (Exception e) {
+                            System.err.println(this.name + " interrupted by exception " + e);
+                        }
+                    }
+                };
+                list.add(t);
+                t.start();
+                System.err.print(".");
+            }
+        }
+        catch (Throwable t) {
+            System.err.println(t.toString());
+        }
+        System.out.println("final list size: " + list.size());
+    }
+}
+

--- a/JvmKillTestThreads.java
+++ b/JvmKillTestThreads.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.ArrayList;
+import java.util.List;
+
+public final class JvmKillTestThreads {
+	static final Runnable r = new Runnable() {
+		public void run(){
+			try {
+			Thread.currentThread().sleep(Integer.MAX_VALUE);
+			} catch(Exception e) {}
+		}
+	};
+    @SuppressWarnings("InfiniteLoopStatement")
+    public static void main(String[] args) throws Exception {
+        System.out.print("Spawning Threads:");
+        while (true) {
+	    try {
+	        new Thread(r).start();
+                System.out.print(".");
+	    } catch (Throwable t) {
+                System.out.println(t.toString());
+            }
+
+        }
+     }
+}

--- a/JvmKillTestThreadsParallel.java
+++ b/JvmKillTestThreadsParallel.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+public final class JvmKillTestThreadsParallel {
+	static final int PARALLEL_SPAWNING = 20;
+	static CountDownLatch startSignal;
+	static final Runnable spawner = new Runnable() {
+		public void run(){
+			try {
+			startSignal.await();
+			} catch (InterruptedException e) {}
+			while (true) 
+				try {
+			                System.out.print("*");
+	        			new Thread(spawned).start();
+				} catch(Exception e) {}
+		}
+	};
+	static final Runnable spawned = new Runnable() {
+		public void run(){
+			try {
+			Thread.currentThread().sleep(Integer.MAX_VALUE);
+			} catch(Exception e) {}
+		}
+	};
+    @SuppressWarnings("InfiniteLoopStatement")
+    public static void main(String[] args) throws Exception {
+	startSignal = new CountDownLatch(PARALLEL_SPAWNING);
+        System.out.print("Spawning Parallel Thread Spawner Threads:");
+        for (int i=0;i<PARALLEL_SPAWNING;i++) {
+	    try {
+	        new Thread(spawner).start();
+                System.out.print(".");
+		startSignal.countDown();
+	    } catch (Throwable t) {
+                System.out.println(t.toString());
+            }
+
+        }
+     }
+}

--- a/Makefile
+++ b/Makefile
@@ -8,24 +8,75 @@ else
   INCLUDE= -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/linux"
 endif
 
-CFLAGS=-Wall -Werror -fPIC -shared $(INCLUDE)
+CFLAGS=-Wall -Werror -fPIC -std=c++11 -shared -fno-strict-aliasing -Wl,-soname=libJvmKill -static-libgcc  -fno-omit-frame-pointer $(INCLUDE)
 TARGET=libjvmkill.so
 
-.PHONY: all clean test
+.PHONY: all build clean alltests ctests threadtests threadtestbasic threadtest0 threadtest-10-2 memtests memtest0 memtest-10-2
 
-all:
-	gcc $(CFLAGS) -o $(TARGET) jvmkill.c
+all: build alltests
+
+build:	
+	@echo "=============================================="
+	g++ $(CFLAGS) -o $(TARGET) jvmkill.c
 	chmod 644 $(TARGET)
 
 clean:
+	@echo "=============================================="
 	rm -f $(TARGET)
 	rm -f *.class
 	rm -f *.hprof
+	rm -f tests
 
-test: all
-	$(JAVA_HOME)/bin/javac JvmKillTest.java
-	$(JAVA_HOME)/bin/java -Xmx1m \
-	    -XX:+HeapDumpOnOutOfMemoryError \
-	    -XX:OnOutOfMemoryError='/bin/echo hello' \
+alltests: ctests threadtests memtests
+
+ctests: build
+	@echo "=============================================="
+	gcc -g -Wall -Werror $(INCLUDE) -ldl -o tests tests.c
+	./tests
+
+threadtests: threadtestbasic threadtest0 threadtest-10-2 threadtestpspawn-10-2
+
+threadtest0: build
+	@echo "=============================================="
+	$(JAVA_HOME)/bin/javac JvmKillTestThreads.java
+	!($(JAVA_HOME)/bin/java -Xmx1m \
 	    -agentpath:$(PWD)/$(TARGET) \
-	    -cp $(PWD) JvmKillTest
+	    -cp $(PWD) JvmKillTestThreads)
+
+threadtest-10-2: build
+	@echo "=============================================="
+	!($(JAVA_HOME)/bin/java -Xmx1m \
+	    -agentpath:$(PWD)/$(TARGET)=time=10,count=2 \
+	    -cp $(PWD) JvmKillTestThreads)
+
+memtests: memtest0 memtest-10-2
+
+memtest0: build
+	@echo "=============================================="
+	$(JAVA_HOME)/bin/javac JvmKillTest.java
+	!($(JAVA_HOME)/bin/java -Xmx5m \
+	    -agentpath:$(PWD)/$(TARGET) \
+	    -cp $(PWD) JvmKillTest)
+
+
+memtest-10-2: build
+	@echo "=============================================="
+	$(JAVA_HOME)/bin/javac JvmKillTest.java
+	($(JAVA_HOME)/bin/java -Xmx5m \
+	    -agentpath:$(PWD)/$(TARGET)=time=10,count=2 \
+	    -cp $(PWD) JvmKillTest)
+
+threadtestbasic: build
+	@echo "=============================================="
+	$(JAVA_HOME)/bin/javac JvmKillTest2.java
+	ulimit -u 
+	!($(JAVA_HOME)/bin/java \
+	    -agentpath:$(PWD)/$(TARGET) \
+	    -cp $(PWD) JvmKillTest2)
+
+threadtestpspawn-10-2: build
+	@echo "=============================================="
+	$(JAVA_HOME)/bin/javac JvmKillTestThreadsParallel.java
+	!($(JAVA_HOME)/bin/java \
+	    -agentpath:$(PWD)/$(TARGET)=time=10,count=2 \
+	    -cp $(PWD) JvmKillTestThreadsParallel)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,21 @@ motivated the development of this agent.
 
 Run Java with the agent added as a JVM argument:
 
-    -agentpath:/path/to/libjvmkill.so
+    -agentpath:/path/to/libjvmkill.so=<parameters>
 
 Alternatively, if modifying the Java command line is not possible, the
 above may be added to the `JAVA_TOOL_OPTIONS` environment variable.
+
+# Agent parameters
+
+The agent configurations can be passed using the standard agent mechanism passing.
+The parameters should be passed as a comma separated string. Eg.: count=2,time=10
+The agent accepts the following parameters:
+
+## count
+Configures the limit of resourceExhausted events that can be fired in the configured
+time interval. Defaults to 0 if not provided (JVM is killed with a single fired event).
+
+## time
+Configures the time limit (in seconds) in which resourceExhausted events are kept in 
+the counter. Defaults to 1 if not provided.

--- a/jvmkill.c
+++ b/jvmkill.c
@@ -15,52 +15,157 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <time.h>
 
-#include <jvmti.h>
+#include "jvmkill.h"
 
-static void JNICALL
+enum {
+    TIME_OPT = 0,
+    COUNT_OPT,
+    THE_END
+};
+ 
+char *tokens[] = {
+    [TIME_OPT] = strdup("time"),
+    [COUNT_OPT] = strdup("count"),
+    [THE_END] = NULL
+};
+
+static long *events; 
+static int eventIndex = 0;
+static struct Configuration configuration;
+
+void setSignal(int signal) {
+   configuration.signal = signal;
+}
+static long getTimeMillis() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (ts.tv_sec*1000)+(ts.tv_nsec/1000000);
+}
+static long getMillisLimit() {
+   return getTimeMillis()-configuration.time_threshold*1000;
+}
+
+static void addEvent() {
+   events[eventIndex]=getTimeMillis();
+   if (++eventIndex>=configuration.count_threshold) {
+      eventIndex=0;
+   }
+}
+
+static int countEvents() {
+   long millisLimit = getMillisLimit();
+   int count = 0;
+   for (int i=0;i<configuration.count_threshold;i++) {
+      if (events[i] != 0 && events[i]>=millisLimit) 
+	 count++;
+   }
+   return count;
+}
+
+void
 resourceExhausted(
       jvmtiEnv *jvmti_env,
       JNIEnv *jni_env,
       jint flags,
       const void *reserved,
-      const char *description)
-{
-   fprintf(stderr, "ResourceExhausted: killing current process!\n");
-   kill(getpid(), SIGKILL);
+      const char *description) {
+
+   int eventCount = countEvents();
+   fprintf(stderr, "ResourceExhausted! (%d/%d)\n", eventCount+1, configuration.count_threshold);
+   //eventCount was already on threshold before adding the current one
+   if (eventCount == configuration.count_threshold) {
+        fprintf(stderr, "killing current process\n");
+   	kill(getpid(), configuration.signal);
+   }
+   addEvent();
 }
 
-JNIEXPORT jint JNICALL
-Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
-{
-   jvmtiEnv *jvmti;
+int setCallbacks(jvmtiEnv *jvmti) {
    jvmtiError err;
-
-   jint rc = (*vm)->GetEnv(vm, (void **) &jvmti, JVMTI_VERSION);
-   if (rc != JNI_OK) {
-      fprintf(stderr, "ERROR: GetEnv failed: %d\n", rc);
-      return JNI_ERR;
-   }
 
    jvmtiEventCallbacks callbacks;
    memset(&callbacks, 0, sizeof(callbacks));
 
    callbacks.ResourceExhausted = &resourceExhausted;
 
-   err = (*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(callbacks));
+   err = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
    if (err != JVMTI_ERROR_NONE) {
       fprintf(stderr, "ERROR: SetEventCallbacks failed: %d\n", err);
       return JNI_ERR;
    }
 
-   err = (*jvmti)->SetEventNotificationMode(
-         jvmti, JVMTI_ENABLE, JVMTI_EVENT_RESOURCE_EXHAUSTED, NULL);
+   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_RESOURCE_EXHAUSTED, NULL);
    if (err != JVMTI_ERROR_NONE) {
       fprintf(stderr, "ERROR: SetEventNotificationMode failed: %d\n", err);
       return JNI_ERR;
    }
-
+   
    return JNI_OK;
 }
+
+int getCount_Threshold() {
+   return configuration.count_threshold;
+}
+
+int getTime_Threshold() {
+   return configuration.time_threshold;
+}
+
+void setParameters(char *options) {
+   char *subopts;
+   char *value;
+
+   //sets defaults
+   configuration.count_threshold = 0;
+   configuration.time_threshold = 1;
+
+   if (NULL == options)
+       return;
+
+   subopts = options;
+   while (*subopts != '\0')
+      switch (getsubopt (&subopts, tokens, &value)) {
+         case COUNT_OPT:
+            if (value == NULL)
+               abort ();
+            configuration.count_threshold = atoi (value);
+            break;
+         case TIME_OPT:
+            if (value == NULL)
+               abort ();
+            configuration.time_threshold = atoi (value);
+            break;
+         default:
+            /* Unknown suboption. */
+            fprintf (stderr, "Unknown suboption '%s'\n", value);
+            break;
+      }
+   events = new long[configuration.count_threshold];
+   //prefill with a safe value
+   for (int i=0;i<configuration.count_threshold;i++) {
+          events[i]=0;
+   }
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
+{
+   jvmtiEnv *jvmti;
+   
+   configuration.signal = SIGKILL;
+
+   jint rc = vm->GetEnv((void **) &jvmti, JVMTI_VERSION);
+   if (rc != JNI_OK) {
+      fprintf(stderr, "ERROR: GetEnv failed: %d\n", rc);
+      return JNI_ERR;
+   }
+   setParameters(options);	
+   return setCallbacks(jvmti);
+}
+
+

--- a/jvmkill.h
+++ b/jvmkill.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/types.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <jvmti.h>
+
+/**
+ * Configuration struct that holds agent configuration 
+ * === time_threshold is expressed in seconds ===
+ */
+struct Configuration {
+   int count_threshold;
+   int time_threshold; 
+   int signal; 
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * function for overriding unix signal sent when the threshold is reached
+ * === Mainly used on unit tests ===
+ */
+void setSignal(int signal); 
+
+/*
+ * resourceExhausted callback registered in the JVM
+ */
+void resourceExhausted(
+      jvmtiEnv *jvmti_env,
+      JNIEnv *jni_env,
+      jint flags,
+      const void *reserved,
+      const char *description); 
+
+int getTime_Threshold(); 
+int getCount_Threshold(); 
+
+/*
+ * function that parses agent parameters
+ */
+void setParameters(char *options); 
+#ifdef __cplusplus
+}
+#endif
+
+/*
+ * Agent load callback called by the JVM
+ */
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *vm, char *options, void *reserved); 

--- a/tests.c
+++ b/tests.c
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "jvmkill.h"
+
+static void *handle;
+static char *parameters;
+static void (*setSignalFn)(int signal);
+static void (*setParametersFn)(char *options);
+static int (*getTime_ThresholdFn)();
+static int (*getCount_ThresholdFn)();
+static void (*resourceExhaustedFn)(
+      jvmtiEnv *jvmti_env,
+      JNIEnv *jni_env,
+      jint flags,
+      const void *reserved,
+      const char *description);
+
+int sigQuit_sent = 0;
+int moddedSignal = SIGUSR1;
+
+void sig_handler(int signo) {
+	if (signo == moddedSignal)
+		sigQuit_sent = 1;
+}
+
+void* printDlError(void *handle) {
+ 	if (!handle) {
+        	fprintf(stderr, "%s\n", dlerror());
+        	exit(EXIT_FAILURE);
+    	}
+	else
+		return handle;
+}
+
+//loads agent library and fetches external function handles
+void setup() {
+        handle = printDlError(dlopen("libjvmkill.so", RTLD_LAZY));
+	parameters = malloc(sizeof(char) * 1024);
+	if (signal(moddedSignal, sig_handler) == SIG_ERR)
+        	exit(EXIT_FAILURE);
+
+	resourceExhaustedFn = printDlError(dlsym(handle, "resourceExhausted"));
+	setParametersFn = printDlError(dlsym(handle, "setParameters"));
+	getTime_ThresholdFn = printDlError(dlsym(handle, "getTime_Threshold"));
+	getCount_ThresholdFn = printDlError(dlsym(handle, "getCount_Threshold"));
+
+	setSignalFn = printDlError(dlsym(handle, "setSignal"));
+	setSignalFn(moddedSignal);
+}
+
+//unloads agent library
+void teardown() {
+	dlclose(handle);
+	free(parameters);
+}
+
+//tests agent fires signal if threshold is exceeded
+int testSendsSignalIfThresholdExceeded() {
+	sigQuit_sent=0;
+	snprintf(parameters, 1024, "%s", "time=3,count=2"); 
+	setParametersFn(parameters);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	if (!sigQuit_sent)
+           fprintf(stdout, "testSendsSignalIfThresholdExceeded FAILED\n");
+	return sigQuit_sent;
+}
+
+//tests agent doesnt fire signal if threshold is reached but not exceeded
+int testDoesntSendSignalIfThresholdNotExceeded() {
+	sigQuit_sent=0;
+	snprintf(parameters, 1024, "%s", "time=3,count=5");
+	setParametersFn(parameters);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	sleep(6); //waits for counter to "zero" 
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	resourceExhaustedFn(NULL,NULL,5,NULL,NULL);
+	if (sigQuit_sent)
+           fprintf(stdout, "testDoesntSendSignalIfThresholdNotExceeded FAILED\n");
+	return !sigQuit_sent;
+
+}
+
+//tests agent parameters parsing
+int testSetsUpParameters() {
+	snprintf(parameters, 1024, "%s", "time=10,count=5"); 
+	setParametersFn(parameters);
+	return ((getTime_ThresholdFn() == 10) && (getCount_ThresholdFn() == 5));
+}
+
+//tests agent default values and parameters parsing when no parameters are provided 
+int testSetsUpNoParameters() {
+	snprintf(parameters, 1024, "%s", ""); 
+	setParametersFn(parameters);
+	return (getCount_ThresholdFn() == 0 && (getTime_ThresholdFn() == 1));
+}
+
+int main() {
+	setup();
+	int result = (testSendsSignalIfThresholdExceeded() && testDoesntSendSignalIfThresholdNotExceeded() && testSetsUpParameters() && testSetsUpNoParameters());
+	teardown();
+	if (result) {    	
+           fprintf(stdout, "SUCCESS\n");
+	   exit(EXIT_SUCCESS);
+	}
+	else { 
+           fprintf(stdout, "FAILURE\n");
+           exit(EXIT_FAILURE);
+	}	
+}
+


### PR DESCRIPTION
Make the JVMKill agent configurable in the sense that a single resourceExhausted event won't cause the JVM to be terminated.

Issues: #156
