### PR TITLE
Pull the version from cargo

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -10,6 +10,10 @@ PATH=/usr/local/bin:$PATH
 /usr/local/bin/cargo --version
 
 cd jvmkill
+
+VERSION=$(cargo metadata --format-version=1 --no-deps | jq '.workspace_members[] | select(. | startswith("jvmkill "))' | cut -d ' ' -f 2)
+echo "Building version $VERSION"
+
 /usr/local/bin/cargo build --color=always --release -p jvmkill
 
 JFROG_CLI_OFFER_CONFIG=false /usr/local/bin/jfrog rt upload \


### PR DESCRIPTION
Previously the version number used came from the pipeline, but that needs to be kept in sync. This will read cargo metadata & pull out the version number.

When deploying, the Cargo.toml's version property just needs to be adjusted.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>