### PR TITLE
Remove platform

### DIFF
--- a/ci/create-release.sh
+++ b/ci/create-release.sh
@@ -7,24 +7,18 @@ SNAPSHOT=$2
 
 update_release() {
   local file=$1
-  local repository=$2
-  local version=$3
+  local version=$2
 
-  sed -E -i '' "s|(^[ ]*ARTIFACTORY_REPOSITORY:[ ]*).+$|\1$repository|" $file
-  sed -E -i '' "s|(^[ ]*VERSION:[ ]*).+$|\1$version|" $file
+  sed -E -i '' "s|(^version = \").*(\".*)$|\1$version\2|" $file
 }
 
-update_release ci/deploy-bionic.yml libs-release-local $RELEASE
-update_release ci/deploy-osx.yml libs-release-local $RELEASE
-update_release ci/deploy-trusty.yml libs-release-local $RELEASE
+update_release jvmkill/Cargo.toml $RELEASE
 git add .
 git commit --message "v$RELEASE Release"
 
 git tag -s v$RELEASE -m "v$RELEASE"
 git reset --hard HEAD^1
 
-update_release ci/deploy-bionic.yml libs-snapshot-local $SNAPSHOT
-update_release ci/deploy-osx.yml libs-snapshot-local $SNAPSHOT
-update_release ci/deploy-trusty.yml libs-snapshot-local $SNAPSHOT
+update_release jvmkill/Cargo.toml $SNAPSHOT
 git add .
 git commit --message "v$SNAPSHOT Development"

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -14,8 +14,8 @@ export CARGO_UNSTABLE_SPARSE_REGISTRY=true
 cd jvmkill
 
 VERSION=$(cargo metadata --format-version=1 --no-deps | jq '.workspace_members[] | select(. | startswith("jvmkill "))' | cut -d ' ' -f 2 |  sed 's|-|.|')
-if [ -z "${VERSION:-}" ] || [ -z "${PLATFORM:-}" ]; then
-  echo "Version [${VERSION:-}] or Platform [${PLATFORM:-}] is empty, but required"
+if [ -z "${VERSION:-}" ]; then
+  echo "Version [${VERSION:-}] is empty, but required"
   exit 255
 fi
 echo "Building version $VERSION"
@@ -27,4 +27,4 @@ JFROG_CLI_OFFER_CONFIG=false /usr/local/bin/jfrog rt upload \
   --user $ARTIFACTORY_USERNAME \
   --password $ARTIFACTORY_PASSWORD \
   $(ls target/release/libjvmkill.* | grep 'dylib\|so') \
-  $ARTIFACTORY_REPOSITORY/org/cloudfoundry/jvmkill/$VERSION/jvmkill-$(echo $VERSION | sed "s|SNAPSHOT|$(date '+%Y%m%d.%H%M%S')|")-$PLATFORM.so
+  $ARTIFACTORY_REPOSITORY/org/cloudfoundry/jvmkill/$VERSION/jvmkill-$(echo $VERSION | sed "s|SNAPSHOT|$(date '+%Y%m%d.%H%M%S')|").so


### PR DESCRIPTION
It does not seem like we'll need to build platform specific binaries, so this removes the platform from the deploy script.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>