### PR TITLE
Workaround docker bug/limitation

### DIFF
--- a/ci/docker-image/Dockerfile
+++ b/ci/docker-image/Dockerfile
@@ -1,5 +1,10 @@
-ARG from_image=bellsoft/liberica-openjdk-debian:8
 ARG base_image=library/ubuntu:bionic
+ARG from_image=bellsoft/liberica-openjdk-debian:8
+
+# need this hack because of a docker bug
+#  see https://stackoverflow.com/a/63472135/1585136
+FROM ${from_image} as java
+
 FROM ${base_image}
 
 RUN apt-get update && apt-get install -y \
@@ -13,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 
 ENV JAVA_HOME="/usr/lib/jvm/jdk"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
-COPY --from=${from_image} $JAVA_HOME $JAVA_HOME
+COPY --from=java $JAVA_HOME $JAVA_HOME
 
 ENV CARGO_HOME  /usr/local
 ENV RUSTUP_HOME /usr/local


### PR DESCRIPTION
Docker 'COPY --from=' doesn't expand arguments :( This works around that bug/limitation.

See https://stackoverflow.com/a/63472135/1585136

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>