### PR TITLE
Fix version string

### DIFF
--- a/jvmkill/Cargo.toml
+++ b/jvmkill/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "jvmkill"
-version = "1.17.0-BUILD-SNAPSHOT"
+version = "1.17.0.BUILD-SNAPSHOT"
 edition = "2021"
 authors = [
     "Glyn Normington <gnormington@pivotal.io>",


### PR DESCRIPTION
The version number should be `.` separated from the `BUILD-SNAPSHOT` part.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>