### PR TITLE
Fix wrong call of void method dumpHeap()

### DIFF
--- a/jvmkill/src/agentcontroller/heapdump.rs
+++ b/jvmkill/src/agentcontroller/heapdump.rs
@@ -98,7 +98,7 @@ impl super::Action for HeapDump {
                 )
             })?;
 
-            jni_env.call_object_method_with_cstring_jboolean(
+            jni_env.call_void_method_with_cstring_jboolean(
                 hotspot_diagnostic_mxbean,
                 dump_heap_method_id,
                 resolved_heap_dump_path_cstring.clone(),


### PR DESCRIPTION
This is a fix for https://github.com/cloudfoundry/jvmkill/issues/18

It replaces the call to HotSpotDiagnosticMXBBean.dumpHeap(...) via CallObjectMethodA with CallVoidMethodA, since the dumpHeap() method is indeed a void method and the check for the return value formerly done can lead to spurious error messages.
